### PR TITLE
ci: validate PR builds and auto-merge dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: |
+          pnpm slidev build slides-en.md --without-notes --base /${{ github.event.repository.name }}/en/ --out dist/en
+          pnpm slidev build slides-fr.md --without-notes --base /${{ github.event.repository.name }}/fr/ --out dist/fr

--- a/pages/en/slide_16.md
+++ b/pages/en/slide_16.md
@@ -7,5 +7,5 @@ Interactive approach
 - Claude generates a detailed plan
 
 <SlidevVideo v-click controls>
-  <source src="/claude-code-react-questions.mp4" type="video/mp4" />
+  <source :src="'/claude-code-react-questions.mp4'" type="video/mp4" />
 </SlidevVideo>

--- a/pages/en/slide_2.md
+++ b/pages/en/slide_2.md
@@ -10,6 +10,6 @@
 
 </div>
 <div>
-<img src="/me.jpg" class="rounded-full w-48 h-48 object-cover" />
+<img :src="'/me.jpg'" class="rounded-full w-48 h-48 object-cover" />
 </div>
 </div>

--- a/pages/fr/slide_16.md
+++ b/pages/fr/slide_16.md
@@ -7,5 +7,5 @@ Approche interactive
 - Claude génère un plan détaillé
 
 <SlidevVideo v-click controls>
-  <source src="/claude-code-react-questions.mp4" type="video/mp4" />
+  <source :src="'/claude-code-react-questions.mp4'" type="video/mp4" />
 </SlidevVideo>

--- a/pages/fr/slide_2.md
+++ b/pages/fr/slide_2.md
@@ -10,6 +10,6 @@
 
 </div>
 <div>
-<img src="/me.jpg" class="rounded-full w-48 h-48 object-cover" />
+<img :src="'/me.jpg'" class="rounded-full w-48 h-48 object-cover" />
 </div>
 </div>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["github>xballoy/renovate-config"],
+  "extends": ["github>xballoy/renovate-config", ":automergeAll"],
   "ignorePaths": ["demo"]
 }


### PR DESCRIPTION
## Summary
- Add a `build` job that runs on every pull request (and `workflow_dispatch`) to build both the EN and FR Slidev decks, so dependency bumps and other changes are vetted before merge.
- Extend `renovate.json` with the `:automergeAll` preset so Renovate auto-merges dependency PRs once they're mergeable.

## Notes
- Renovate's automerge only waits for green CI when the target branch enforces required status checks (or the Renovate config sets `requiredStatusChecks`). To gate auto-merge on the new `build` job, enable branch protection on `main` with `build` marked as required.

## Test plan
- [ ] Open this PR and confirm the `build` job runs and succeeds against the PR HEAD.
- [ ] After merge, verify the next Renovate PR runs CI and auto-merges once green (assuming branch protection is configured).