### PR TITLE
chore: redirect /en and /fr deep links

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Moved — see xballoy/presentations</title>
+  <meta http-equiv="refresh" content="0; url=https://xballoy.github.io/presentations/ai-tech-debt/en/">
+  <link rel="canonical" href="https://xballoy.github.io/presentations/ai-tech-debt/en/">
+</head>
+<body>
+  <p>This talk has moved to
+    <a href="https://xballoy.github.io/presentations/ai-tech-debt/en/">xballoy.github.io/presentations/ai-tech-debt/en</a>.</p>
+</body>
+</html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="utf-8">
+  <title>Déplacé — voir xballoy/presentations</title>
+  <meta http-equiv="refresh" content="0; url=https://xballoy.github.io/presentations/ai-tech-debt/fr/">
+  <link rel="canonical" href="https://xballoy.github.io/presentations/ai-tech-debt/fr/">
+</head>
+<body>
+  <p>Cette présentation a été déplacée vers
+    <a href="https://xballoy.github.io/presentations/ai-tech-debt/fr/">xballoy.github.io/presentations/ai-tech-debt/fr</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Adds en/ and fr/ redirect stubs so previously-advertised deep links keep working after the switch to deploy-from-branch.